### PR TITLE
✨ feat: create carousel routine template

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
       }
     ],
     "react/no-unescaped-entities": "off",
+    "react/require-default-props": "off",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-misused-promises": "off",
     "@typescript-eslint/no-floating-promises": "off"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "@expo/vector-icons": "^13.0.0",
     "@gorhom/bottom-sheet": "^4",
+    "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-native-masked-view/masked-view": "0.2.7",
     "@react-navigation/native": "^6.0.12",
     "@react-navigation/stack": "^6.2.3",
-    "@react-native-async-storage/async-storage": "~1.17.3",
     "expo": "~46.0.9",
     "expo-status-bar": "~1.4.0",
     "react": "18.0.0",
@@ -22,8 +22,8 @@
     "react-native": "0.69.5",
     "react-native-gesture-handler": "~2.5.0",
     "react-native-reanimated": "~2.9.1",
-    "react-native-safe-area-context": "^4.3.3",
-    "react-native-screens": "^3.17.0",
+    "react-native-safe-area-context": "4.3.1",
+    "react-native-screens": "~3.15.0",
     "react-native-web": "~0.18.7"
   },
   "devDependencies": {

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -1,8 +1,13 @@
-import { useRef, useMemo, useCallback } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import { Dimensions, StyleSheet, View } from "react-native";
 
-import BottomSheet from "@gorhom/bottom-sheet";
+import {
+  BottomSheetModal,
+  BottomSheetModalProvider,
+  BottomSheetView,
+} from "@gorhom/bottom-sheet";
+import { MaterialIcons } from "@expo/vector-icons";
 
 import Carousel from "./Carousel";
 
@@ -49,41 +54,57 @@ const mockCards = [
 const { width: screenWidth } = Dimensions.get("screen");
 
 export default function BottomDrawer() {
-  const bottomSheetRef = useRef<BottomSheet>(null);
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-  const snapPoints = useMemo(() => ["20%", "100%"], []);
+  const snapPoints = useMemo(() => ["50%", "100%"], []);
+
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
   const handleSheetChanges = useCallback((index: number) => {
     console.log("handleSheetChanges", index);
   }, []);
 
   return (
-    <View style={styles.bottomSheetContainer}>
-      <BottomSheet
-        ref={bottomSheetRef}
-        index={1}
-        snapPoints={snapPoints}
-        backgroundStyle={styles.bottomSheetBackground}
-        handleIndicatorStyle={styles.handleIndicator}
-        onChange={handleSheetChanges}
-      >
-        <View style={styles.contentContainer}>
-          <Carousel
-            cards={mockCards}
-            cardWidth={screenWidth * 0.67}
-            gap={screenWidth * 0.08}
-            offset={screenWidth * 0.1}
-          />
-        </View>
-      </BottomSheet>
-    </View>
+    <BottomSheetModalProvider>
+      <View style={styles.bottomSheetContainer}>
+        <MaterialIcons
+          name="drag-handle"
+          size={24}
+          color="#fff"
+          title="Present Modal"
+          onPress={handlePresentModalPress}
+        />
+        <BottomSheetModal
+          ref={bottomSheetModalRef}
+          index={0}
+          snapPoints={snapPoints}
+          backgroundStyle={styles.bottomSheetBackground}
+          handleIndicatorStyle={styles.handleIndicator}
+          onChange={handleSheetChanges}
+        >
+          <BottomSheetView style={styles.contentContainer}>
+            <Carousel
+              cards={mockCards}
+              cardWidth={screenWidth * 0.67}
+              gap={screenWidth * 0.08}
+              offset={screenWidth * 0.1}
+            />
+          </BottomSheetView>
+        </BottomSheetModal>
+      </View>
+    </BottomSheetModalProvider>
   );
 }
 
 const styles = StyleSheet.create({
   bottomSheetContainer: {
-    flex: 1,
-    padding: 24,
-    backgroundColor: "#fff",
+    paddingVertical: 16,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#006de9",
+    borderTopLeftRadius: 50,
+    borderTopRightRadius: 50,
   },
   bottomSheetBackground: {
     backgroundColor: "#006de9",
@@ -93,8 +114,8 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     flex: 1,
-    justifyContent: "flex-start",
-    paddingTop: 30,
+    justifyContent: "center",
+    alignItems: "center",
     backgroundColor: "#006de9",
   },
 });

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -77,7 +77,7 @@ export default function BottomDrawer() {
         />
         <BottomSheetModal
           ref={bottomSheetModalRef}
-          index={0}
+          index={1}
           snapPoints={snapPoints}
           backgroundStyle={styles.bottomSheetBackground}
           handleIndicatorStyle={styles.handleIndicator}
@@ -102,12 +102,12 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#006de9",
+    backgroundColor: "rgba(0, 109, 233, 0.8)",
     borderTopLeftRadius: 50,
     borderTopRightRadius: 50,
   },
   bottomSheetBackground: {
-    backgroundColor: "#006de9",
+    backgroundColor: "rgba(0, 109, 233, 0.8)",
   },
   handleIndicator: {
     backgroundColor: "#fff",
@@ -116,6 +116,5 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
-    backgroundColor: "#006de9",
   },
 });

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -8,24 +8,41 @@ import Carousel from "./Carousel";
 
 const mockCards = [
   {
+    index: 0,
+    routineTitle: "Morning Routine",
+    routineList: [
+      { id: 0, description: "침대 정리", status: false },
+      { id: 1, description: "아침 운동", status: false },
+    ],
+  },
+  {
     index: 1,
-    contents: "test text",
+    routineTitle: "Work Routine",
+    routineList: [
+      { id: 0, description: "자료 조사", status: false },
+      { id: 1, description: "미팅 준비", status: false },
+    ],
   },
   {
     index: 2,
-    contents: "test text",
+    routineTitle: "Diet Routine",
+    routineList: [
+      { id: 0, description: "비타민 복용", status: false },
+      { id: 1, description: "커피 한잔", status: false },
+    ],
   },
   {
     index: 3,
-    contents: "test text",
+    routineTitle: "Bedtime Routine",
+    routineList: [
+      { id: 0, description: "강아지 산책", status: false },
+      { id: 1, description: "요가 스트레칭", status: false },
+    ],
   },
   {
     index: 4,
-    contents: "test text",
-  },
-  {
-    index: 5,
-    contents: "test text",
+    routineTitle: "",
+    routineList: [{ id: 0, description: "", status: false }],
   },
 ];
 
@@ -77,7 +94,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     flex: 1,
     justifyContent: "flex-start",
-    paddingTop: 20,
+    paddingTop: 30,
     backgroundColor: "#006de9",
   },
 });

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -11,38 +11,38 @@ const mockCards = [
     index: 0,
     routineTitle: "Morning Routine",
     routineList: [
-      { id: 0, description: "침대 정리", status: false },
-      { id: 1, description: "아침 운동", status: false },
+      { id: "1662706569216", text: "침대 정리", isChecked: false },
+      { id: "1662706569217", text: "아침 운동", isChecked: false },
     ],
   },
   {
     index: 1,
     routineTitle: "Work Routine",
     routineList: [
-      { id: 0, description: "자료 조사", status: false },
-      { id: 1, description: "미팅 준비", status: false },
+      { id: "1662706569218", text: "자료 조사", isChecked: false },
+      { id: "1662706569219", text: "미팅 준비", isChecked: false },
     ],
   },
   {
     index: 2,
     routineTitle: "Diet Routine",
     routineList: [
-      { id: 0, description: "비타민 복용", status: false },
-      { id: 1, description: "커피 한잔", status: false },
+      { id: "1662706569220", text: "비타민 복용", isChecked: false },
+      { id: "1662706569221", text: "커피 한잔", isChecked: false },
     ],
   },
   {
     index: 3,
     routineTitle: "Bedtime Routine",
     routineList: [
-      { id: 0, description: "강아지 산책", status: false },
-      { id: 1, description: "요가 스트레칭", status: false },
+      { id: "1662706569222", text: "강아지 산책", isChecked: false },
+      { id: "1662706569223", text: "요가 스트레칭", isChecked: false },
     ],
   },
   {
     index: 4,
     routineTitle: "",
-    routineList: [{ id: 0, description: "", status: false }],
+    routineList: [{ id: "", text: "", isChecked: false }],
   },
 ];
 

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 
-import { Dimensions, StyleSheet, View } from "react-native";
+import { Dimensions, StyleSheet, View, Pressable } from "react-native";
 
 import {
   BottomSheetModal,
@@ -67,32 +67,37 @@ export default function BottomDrawer() {
 
   return (
     <BottomSheetModalProvider>
-      <View style={styles.bottomSheetContainer}>
-        <MaterialIcons
-          name="drag-handle"
-          size={24}
-          color="#fff"
-          title="Present Modal"
-          onPress={handlePresentModalPress}
-        />
-        <BottomSheetModal
-          ref={bottomSheetModalRef}
-          index={1}
-          snapPoints={snapPoints}
-          backgroundStyle={styles.bottomSheetBackground}
-          handleIndicatorStyle={styles.handleIndicator}
-          onChange={handleSheetChanges}
-        >
-          <BottomSheetView style={styles.contentContainer}>
-            <Carousel
-              cards={mockCards}
-              cardWidth={screenWidth * 0.67}
-              gap={screenWidth * 0.08}
-              offset={screenWidth * 0.1}
-            />
-          </BottomSheetView>
-        </BottomSheetModal>
-      </View>
+      <Pressable
+        onPress={handlePresentModalPress}
+        style={({ pressed }) => [{ opacity: pressed ? 0.5 : 1.0 }]}
+      >
+        <View style={styles.bottomSheetContainer}>
+          <MaterialIcons
+            name="drag-handle"
+            size={24}
+            color="#fff"
+            title="Present Modal"
+            onPress={handlePresentModalPress}
+          />
+          <BottomSheetModal
+            ref={bottomSheetModalRef}
+            index={1}
+            snapPoints={snapPoints}
+            backgroundStyle={styles.bottomSheetBackground}
+            handleIndicatorStyle={styles.handleIndicator}
+            onChange={handleSheetChanges}
+          >
+            <BottomSheetView style={styles.contentContainer}>
+              <Carousel
+                cards={mockCards}
+                cardWidth={screenWidth * 0.67}
+                gap={screenWidth * 0.08}
+                offset={screenWidth * 0.1}
+              />
+            </BottomSheetView>
+          </BottomSheetModal>
+        </View>
+      </Pressable>
     </BottomSheetModalProvider>
   );
 }

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -10,6 +10,8 @@ import {
 
 import { ICarousel, ICardData } from "../types";
 
+import CarouselCard from "./CarouselCard";
+
 export default function Carousel({ cards, cardWidth, gap, offset }: ICarousel) {
   const [cardNum, setCardNum] = useState<number>(0);
 
@@ -21,31 +23,8 @@ export default function Carousel({ cards, cardWidth, gap, offset }: ICarousel) {
     setCardNum(newCardNum);
   };
 
-  const renderCards = (curIndex: number) => {
-    const scaleValue = cardNum === curIndex ? 1 : 0.8;
-    const opacityValue = cardNum === curIndex ? 1 : 0.6;
-    const translateYValue = cardNum === curIndex ? 0 : 15;
-
-    return (
-      <View
-        style={[
-          styles.carouselCard,
-          {
-            width: cardWidth,
-            transform: [
-              { scaleY: scaleValue },
-              { translateY: translateYValue },
-            ],
-            opacity: opacityValue,
-            marginHorizontal: gap / 2,
-          },
-        ]}
-      />
-    );
-  };
-
   const renderIndicators = (curIndex: number) => {
-    const indicatorColor = curIndex === cardNum ? "#fff" : "#3e3e3e";
+    const indicatorColor = curIndex === cardNum ? "#fff" : "#a4a4a4";
 
     return (
       <View
@@ -63,10 +42,19 @@ export default function Carousel({ cards, cardWidth, gap, offset }: ICarousel) {
         data={cards}
         decelerationRate="fast"
         horizontal
-        keyExtractor={(card: ICardData) => `routine_${card.index}`}
+        keyExtractor={({ index }: ICardData) => `routine_${index}`}
         onScroll={onScroll}
         pagingEnabled
-        renderItem={({ index }: ICardData) => renderCards(index)}
+        renderItem={({ item }) => (
+          <CarouselCard
+            cards={cards}
+            cardWidth={cardWidth}
+            gap={gap}
+            offset={offset}
+            curIndex={item.index}
+            cardNum={cardNum}
+          />
+        )}
         showsHorizontalScrollIndicator={false}
         snapToInterval={cardWidth + gap}
         snapToAlignment="start"

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -71,7 +71,6 @@ export default function Carousel({ cards, cardWidth, gap, offset }: ICarousel) {
 const styles = StyleSheet.create({
   carouselContainer: {
     height: "80%",
-    backgroundColor: "#006de9",
   },
   carouselCard: {
     padding: 5,

--- a/src/components/CarouselCard.tsx
+++ b/src/components/CarouselCard.tsx
@@ -1,0 +1,72 @@
+import { FlatList, StyleSheet, Text, View } from "react-native";
+
+import { ICarouselCard, IRoutineItem } from "../types";
+
+import RoutineTemplate from "./RoutineTemplate";
+import TodoItem from "./TodoItem";
+
+export default function CarouselCard({
+  cards,
+  cardWidth,
+  gap,
+  curIndex,
+  cardNum,
+}: ICarouselCard) {
+  const scaleValue = cardNum !== curIndex ? 0.8 : 1;
+  const translateYValue = cardNum !== curIndex ? 15 : 0;
+  const opacityValue =
+    cardNum !== curIndex || curIndex === cards.length - 1 ? 0.6 : 1;
+
+  const renderItem = (item: IRoutineItem) => {
+    const lastTemplateItem = cards.length - 1;
+
+    return curIndex !== lastTemplateItem ? (
+      <TodoItem
+        id={item.id}
+        description={item.description}
+        status={item.status}
+      />
+    ) : (
+      <RoutineTemplate />
+    );
+  };
+
+  return (
+    <View
+      style={[
+        styles.carouselCard,
+        {
+          width: cardWidth,
+          marginHorizontal: gap / 2,
+          padding: 15,
+          transform: [{ scaleY: scaleValue }, { translateY: translateYValue }],
+          opacity: opacityValue,
+        },
+      ]}
+    >
+      <Text>{cards[curIndex].routineTitle}</Text>
+      <FlatList
+        contentContainerStyle={{}}
+        automaticallyAdjustContentInsets={false}
+        data={cards[curIndex].routineList}
+        keyExtractor={({ id }: IRoutineItem) =>
+          `routine_${cards[curIndex].routineTitle}_${id}`
+        }
+        renderItem={({ item }) => renderItem(item)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  carouselCard: {
+    padding: 5,
+    borderRadius: 25,
+    backgroundColor: "#fff",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.3,
+    shadowRadius: 5,
+    elevation: 2,
+  },
+});

--- a/src/components/CarouselCard.tsx
+++ b/src/components/CarouselCard.tsx
@@ -21,11 +21,7 @@ export default function CarouselCard({
     const lastTemplateItem = cards.length - 1;
 
     return curIndex !== lastTemplateItem ? (
-      <TodoItem
-        id={item.id}
-        description={item.description}
-        status={item.status}
-      />
+      <TodoItem id={item.id} text={item.text} isChecked={item.isChecked} />
     ) : (
       <RoutineTemplate />
     );

--- a/src/components/CarouselCard.tsx
+++ b/src/components/CarouselCard.tsx
@@ -42,7 +42,6 @@ export default function CarouselCard({
     >
       <Text>{cards[curIndex].routineTitle}</Text>
       <FlatList
-        contentContainerStyle={{}}
         automaticallyAdjustContentInsets={false}
         data={cards[curIndex].routineList}
         keyExtractor={({ id }: IRoutineItem) =>

--- a/src/components/Routine.tsx
+++ b/src/components/Routine.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, Text, TextInput } from "react-native";
 export default function Routine() {
   return (
     <View style={styles.textInput}>
-      <Text style={styles.routinLabel}>Today Routine</Text>
+      <Text style={styles.routineLabel}>Today Routine</Text>
       <TextInput style={styles.routineInput} returnKeyType="done" />
     </View>
   );
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
   textInput: {
     width: "100%",
   },
-  routinLabel: {
+  routineLabel: {
     fontSize: 15,
     fontWeight: "700",
     color: "#006de9",
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
   },
   routineInput: {
     fontSize: 15,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "#fff",
     justifyContent: "center",
     paddingVertical: 5,
     paddingHorizontal: 5,

--- a/src/components/RoutineTemplate.tsx
+++ b/src/components/RoutineTemplate.tsx
@@ -1,0 +1,31 @@
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+
+import { Entypo } from "@expo/vector-icons";
+
+export default function RoutineTemplate() {
+  const handleCardClick = () => {
+    console.log("carouselCard clicked!");
+  };
+
+  return (
+    <TouchableOpacity onPress={handleCardClick}>
+      <View style={styles.templateContainer}>
+        <Entypo
+          name="plus"
+          size={24}
+          color="#1a81f4"
+          style={{
+            paddingTop: 30,
+          }}
+        />
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  templateContainer: {
+    flex: 1,
+    alignItems: "center",
+  },
+});

--- a/src/components/RoutineTemplate.tsx
+++ b/src/components/RoutineTemplate.tsx
@@ -4,7 +4,7 @@ import { Entypo } from "@expo/vector-icons";
 
 export default function RoutineTemplate() {
   const handleCardClick = () => {
-    console.log("carouselCard clicked!");
+    console.log("Would you like to create a new routine?");
   };
 
   return (

--- a/src/components/TitleInput.tsx
+++ b/src/components/TitleInput.tsx
@@ -65,7 +65,7 @@ const styles = StyleSheet.create({
   },
   titleInput: {
     fontSize: 15,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "#fff",
     borderBottomWidth: 0.5,
     borderColor: "#808080",
     justifyContent: "center",

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -15,9 +15,9 @@ export default function TodoItem({
   id: string;
   text: string;
   isChecked: boolean;
-  onCheckboxPress: () => void;
-  onChangeText: (text: SetStateAction<string>) => void;
-  onSaveTodo: () => Promise<void>;
+  onCheckboxPress?: () => void;
+  onChangeText?: (text: SetStateAction<string>) => void;
+  onSaveTodo?: () => Promise<void>;
 }) {
   return (
     <View style={styles.container}>

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -63,14 +63,14 @@ const styles = StyleSheet.create({
     backgroundColor: "transparent",
   },
   checkboxChecked: {
-    backgroundColor: "#ffffff",
+    backgroundColor: "#fff",
   },
   textInput: {
     width: "100%",
   },
   todoInput: {
     fontSize: 15,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "#fff",
     justifyContent: "center",
     paddingVertical: 10,
     paddingHorizontal: 5,

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { StatusBar } from "expo-status-bar";
 import {
   Keyboard,
+  KeyboardAvoidingView,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -29,7 +30,7 @@ export default function MainScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <View style={styles.container}>
+      <KeyboardAvoidingView style={styles.container} behavior="padding">
         <StatusBar style="auto" />
         <View style={styles.header}>
           <TouchableHighlight
@@ -46,7 +47,7 @@ export default function MainScreen() {
           <TodoList />
         </View>
         <BottomDrawer />
-      </View>
+      </KeyboardAvoidingView>
     </TouchableWithoutFeedback>
   );
 }
@@ -64,11 +65,11 @@ const styles = StyleSheet.create({
   btnText: {
     fontSize: 28,
     fontWeight: "600",
-    color: "#FFFFFF",
+    color: "#fff",
   },
   contents: {
     flex: 1.8,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "#fff",
     borderTopStartRadius: 50,
     borderTopEndRadius: 50,
     paddingHorizontal: 20,

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -34,28 +34,28 @@ export default function MainScreen() {
       style={{ flex: 1 }}
       behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
-      <StatusBar style="auto" />
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <TouchableHighlight
-              onPress={() => console.log("pressed!")}
-              underlayColor="#006de9"
-              activeOpacity={0.5}
-            >
-              <Text style={styles.btnText}>{date}</Text>
-            </TouchableHighlight>
-          </View>
-          <View style={styles.contentsContainer}>
+      <View style={styles.container}>
+        <StatusBar style="auto" />
+        <View style={styles.header}>
+          <TouchableHighlight
+            onPress={() => console.log("pressed!")}
+            underlayColor="#006de9"
+            activeOpacity={0.5}
+          >
+            <Text style={styles.btnText}>{date}</Text>
+          </TouchableHighlight>
+        </View>
+        <View style={styles.contentsContainer}>
+          <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
             <View style={styles.todayRoutineContainer}>
               <TitleInput />
               <Routine />
               <TodoList />
             </View>
-            <BottomDrawer />
-          </View>
+          </TouchableWithoutFeedback>
+          <BottomDrawer />
         </View>
-      </TouchableWithoutFeedback>
+      </View>
     </KeyboardAvoidingView>
   );
 }

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from "expo-status-bar";
 import {
   Keyboard,
   KeyboardAvoidingView,
+  Platform,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -29,26 +30,33 @@ export default function MainScreen() {
   }, []);
 
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <KeyboardAvoidingView style={styles.container} behavior="padding">
-        <StatusBar style="auto" />
-        <View style={styles.header}>
-          <TouchableHighlight
-            onPress={() => console.log("pressed!")}
-            underlayColor="#006de9"
-            activeOpacity={0.5}
-          >
-            <Text style={styles.btnText}>{date}</Text>
-          </TouchableHighlight>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      <StatusBar style="auto" />
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <View style={styles.container}>
+          <View style={styles.header}>
+            <TouchableHighlight
+              onPress={() => console.log("pressed!")}
+              underlayColor="#006de9"
+              activeOpacity={0.5}
+            >
+              <Text style={styles.btnText}>{date}</Text>
+            </TouchableHighlight>
+          </View>
+          <View style={styles.contentsContainer}>
+            <View style={styles.todayRoutineContainer}>
+              <TitleInput />
+              <Routine />
+              <TodoList />
+            </View>
+            <BottomDrawer />
+          </View>
         </View>
-        <View style={styles.contents}>
-          <TitleInput />
-          <Routine />
-          <TodoList />
-        </View>
-        <BottomDrawer />
-      </KeyboardAvoidingView>
-    </TouchableWithoutFeedback>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -60,19 +68,22 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     justifyContent: "center",
-    marginTop: 100,
+    marginTop: 60,
   },
   btnText: {
     fontSize: 28,
     fontWeight: "600",
     color: "#fff",
   },
-  contents: {
+  contentsContainer: {
     flex: 1.8,
     backgroundColor: "#fff",
     borderTopStartRadius: 50,
     borderTopEndRadius: 50,
+    marginTop: 30,
+  },
+  todayRoutineContainer: {
+    flex: 1,
     paddingHorizontal: 20,
-    marginTop: 50,
   },
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,9 +4,16 @@ export type RootStackParamList = {
   BottomDrawer: undefined;
 }
 
+export interface IRoutineItem {
+  id: number;
+  description: string;
+  status: boolean;
+}
+
 export interface ICardData {
   index: number;
-  contents?: string;
+  routineTitle: string;
+  routineList: IRoutineItem[];
 }
 
 export interface ICarousel {
@@ -14,4 +21,9 @@ export interface ICarousel {
   cardWidth: number;
   gap: number;
   offset: number;
+}
+
+export interface ICarouselCard extends ICarousel{
+  curIndex: number;
+  cardNum: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,9 +5,9 @@ export type RootStackParamList = {
 }
 
 export interface IRoutineItem {
-  id: number;
-  description: string;
-  status: boolean;
+  id: string;
+  text: string;
+  isChecked: boolean;
 }
 
 export interface ICardData {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6544,15 +6544,15 @@ react-native-redash@^16.1.1:
     normalize-svg-path "^1.0.1"
     parse-svg-path "^0.1.2"
 
-react-native-safe-area-context@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"
-  integrity sha512-xwsloGLDUzeTN40TIh4Te/zRePSnBAuWlLIiEW3RYE9gHHYslqQWpfK7N24SdAQEH3tHZ+huoYNjo2GQJO/vnQ==
+react-native-safe-area-context@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.1.tgz#5cf97b25b395e0d09bc1f828920cd7da0d792ade"
+  integrity sha512-cEr7fknJCToTrSyDCVNg0GRdRMhyLeQa2NZwVCuzEQcWedOw/59ExomjmzCE4rxrKXs6OJbyfNtFRNyewDaHuA==
 
-react-native-screens@^3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.17.0.tgz#b099b3ec9d46de07c857f14d713c293024c7c842"
-  integrity sha512-OZCQU7+3neHNaM19jBkYRjL50kXz7p7MUgWQTCcdRoshcCiolf8aXs4eRVQKGK6m1RmoB8UL0//m5R9KoR+41w==
+react-native-screens@~3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.15.0.tgz#78e42c8df72851b1ff235ddf5434b961ae123ca5"
+  integrity sha512-ezC5TibsUYyqPuuHpZoM3iEl6bRzCVBMJeGaFkn7xznuOt1VwkZVub0BvafIEYR/+AQC/RjxzMSQPs1qal0+wA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
## Task

- [Carousel 컴포넌트 구현 (2/2)](https://www.notion.so/taewan/Carousel-2-2-2e83d18a65d34f7fb1d7dc41447ae853)

## Description

- 유저는 `Carousel` 컴포넌트에서 루틴 탬플릿 생성을 위한 버튼 클릭 가능

## Key Points 1

- `Carousel` card 에서 routine 아이템들이 현재는 `TodoItem` 컴포넌트로 FlatList 되고 있습니다. 
*(현재 routine 아이템의 CRUD 를 적용하지 못한 상태입니다)
- 아래 부분은 아직 TodoItem 재사용성있게 routine 에서도 사용하지 못해서 우선 optional 처리 해두었습니다.
  ``` 
  onCheckboxPress?: () => void;
  onChangeText?: (text: SetStateAction<string>) => void;
  onSaveTodo?: () => Promise<void>;

## Key Points 2
- BottomSheet 가 닫혀있을 때도, 스크린의 공간을 차지하고 있어서, 대신 BottomSheetModal 로 변경 
- BottomSheetModal 내부 카루젤 가로스크롤이 안먹어서 Keyboard.dismiss wrapper 에서 BottomSheet 제외
- BottomSheetModal 의 opacity 때문에 hex code 에서r rgba 로 변경
- BottomSheet 클릭할 때 Pressable wrapper 활용해서 opacity 적용 (클릭해야 BottomSheetModal 이 올라가는데 드래그로 헷갈릴까봐...)

## Anything to add

- `TodoItem` 컴포넌트를 routine item 으로 재사용하기엔 데이터를 정리하기 어렵지 않을까 싶습니다 -> Async storage 에 routine 을 위한 다른 데이터 스키마가 생겨야 할 듯 합니다.
(`TodoItem` 의 CRUD 기능과 모양은 재사용할 수 있겠지만, 데이터는 각각 다른 데이터 스키마를 생성해서 유지해야 하는 상황인 듯 한데, 어떻게 생각하시나요?)