### PR TITLE
🐛 fix: modify todo item to be saved even when it has no text

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -18,6 +18,7 @@ export default function TodoItem({
   onCheckboxPress,
   onChangeText,
   onSaveTodo,
+  onEditTodo,
   onDeleteTodo,
 }: {
   id: number;
@@ -27,6 +28,7 @@ export default function TodoItem({
   onCheckboxPress?: () => void;
   onChangeText?: (text: SetStateAction<string>) => void;
   onSaveTodo?: () => Promise<void>;
+  onEditTodo?: () => Promise<void>;
   onDeleteTodo?: () => void;
 }) {
   const onDragNDrop = () => {};
@@ -63,7 +65,8 @@ export default function TodoItem({
           returnKeyType="done"
           value={text}
           onChangeText={onChangeText}
-          onEndEditing={onSaveTodo}
+          onEndEditing={onEditTodo}
+          onSubmitEditing={onSaveTodo}
           onKeyPress={handleKeyPress}
         />
         <TouchableOpacity onPress={onDeleteTodo} activeOpacity={0.5}>

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -12,6 +12,7 @@ import { AntDesign, Entypo, MaterialIcons } from "@expo/vector-icons";
 
 export default function TodoItem({
   id,
+  index,
   text,
   isChecked,
   onCheckboxPress,
@@ -20,6 +21,7 @@ export default function TodoItem({
   onDeleteTodo,
 }: {
   id: number;
+  index: number;
   text: string;
   isChecked: boolean;
   onCheckboxPress?: () => void;
@@ -28,6 +30,18 @@ export default function TodoItem({
   onDeleteTodo?: () => void;
 }) {
   const onDragNDrop = () => {};
+
+  const handleKeyPress = ({
+    nativeEvent: { key: keyValue },
+  }: {
+    nativeEvent: { key: string };
+  }) => {
+    if (keyValue === "Backspace" && text === "" && index !== 0) {
+      if (!onDeleteTodo) return;
+
+      onDeleteTodo();
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -50,6 +64,7 @@ export default function TodoItem({
           value={text}
           onChangeText={onChangeText}
           onSubmitEditing={onSaveTodo}
+          onKeyPress={handleKeyPress}
         />
         <TouchableOpacity onPress={onDeleteTodo} activeOpacity={0.5}>
           {text !== "" && <AntDesign name="delete" size={20} color="#808080" />}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -63,7 +63,7 @@ export default function TodoItem({
           returnKeyType="done"
           value={text}
           onChangeText={onChangeText}
-          onSubmitEditing={onSaveTodo}
+          onEndEditing={onSaveTodo}
           onKeyPress={handleKeyPress}
         />
         <TouchableOpacity onPress={onDeleteTodo} activeOpacity={0.5}>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -39,8 +39,6 @@ export default function TodoList({
 
   const onSaveTodo = async (index: number) => {
     try {
-      await AsyncStorage.setItem(storageKey, JSON.stringify(todos));
-
       if (index + 1 === todos.length) {
         const newTodo = {
           id: Date.now(),
@@ -49,6 +47,10 @@ export default function TodoList({
           isChecked: false,
         };
 
+        await AsyncStorage.setItem(
+          storageKey,
+          JSON.stringify([...todos, newTodo]),
+        );
         setTodos(prevTodos => [...prevTodos, newTodo]);
       }
     } catch (error) {
@@ -96,6 +98,7 @@ export default function TodoList({
     return (
       <TodoItem
         id={item.id}
+        index={index}
         text={item.text}
         isChecked={item.isChecked}
         onCheckboxPress={() => {

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -58,6 +58,38 @@ export default function TodoList({
     }
   };
 
+  const onEditTodo = async () => {
+    try {
+      await AsyncStorage.setItem(storageKey, JSON.stringify([...todos]));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const onDeleteTodo = async (index: number) => {
+    try {
+      if (todos.length === 1) {
+        const newTodos = [...todos];
+
+        newTodos[index].text = "";
+        newTodos[index].isChecked = false;
+        setTodos([...newTodos]);
+
+        return;
+      }
+
+      const newTodos = todos.filter((item, filterIndex) => {
+        return index !== filterIndex;
+      });
+
+      setTodos([...newTodos]);
+
+      await AsyncStorage.setItem(storageKey, JSON.stringify(newTodos));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   useEffect(() => {
     const onLoadTodos = async () => {
       try {
@@ -73,20 +105,6 @@ export default function TodoList({
 
     onLoadTodos();
   }, [storageKey]);
-
-  const onDeleteTodo = async (index: number) => {
-    try {
-      const newTodos = todos.filter((item, filterIndex) => {
-        return index !== filterIndex;
-      });
-
-      setTodos([...newTodos]);
-
-      await AsyncStorage.setItem(storageKey, JSON.stringify(newTodos));
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   const renderItem = ({
     item,
@@ -109,6 +127,9 @@ export default function TodoList({
         }}
         onSaveTodo={async () => {
           await onSaveTodo(index);
+        }}
+        onEditTodo={async () => {
+          await onEditTodo();
         }}
         onDeleteTodo={() => {
           onDeleteTodo(index);


### PR DESCRIPTION
## Task

- 

## Description

- 🐛 fix: modify todo item to be saved even when it has no text
- ✨ feat: add deletion method of empty todo item on backspace key press
- 🐛 fix: prevent the creation of an empty string TodoItem when TodoItem is edited

## Key Points

- Fix bug
  - 빈 input 저장 시, 새로운 `TodoItem` 생성이 계속 됐는데, `onSubmitEditing` 과 `onEndEditing` 으로 로직을 나누어 버그 수정
    - `onSubmitEditing` -> `TodoItem` 저장과 동시에 empty string `TodoItem` 생성
    - `onEndEditing` -> `TodoItem` 저장만 진행 (empty string `TodoItem` 만들지 않음)
- Add a new deletion method
  - `TodoItem` 이 1개 일 때도 삭제되는 버그 수정
- 추가 기능
  - empty string 인 투두아이템 Backspace 로 삭제 가능하도록 구현

## Anything to add

- 
